### PR TITLE
Swap underscore for dash in hostname

### DIFF
--- a/main.go
+++ b/main.go
@@ -333,7 +333,7 @@ func loop(
 
 	for event := range events {
 
-		name := fmt.Sprint(containerName, "_", i)
+		name := fmt.Sprint(containerName, "-", i)
 		i++
 
 		log.Printf("New container starting: %q", name)


### PR DESCRIPTION
Docker seems to have become more strict about hostnames. It also appears possible that there is (or was) a difference in how this is handled in the docker client vs in the server.

In this case we use "-" instead of "_" to separate the run number in the host name.