### PR TITLE
Supply empty authentication during push

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"log"
 	"net/http"
@@ -75,7 +76,11 @@ func Action(c *cli.Context) {
 			return fmt.Errorf("tagimage: %v", err2)
 		}
 
-		rc, err2 := client.ImagePush(context.TODO(), ref, types.ImagePushOptions{})
+		blankAuth := base64.URLEncoding.EncodeToString([]byte("{}"))
+
+		rc, err2 := client.ImagePush(context.TODO(), ref, types.ImagePushOptions{
+			RegistryAuth: blankAuth,
+		})
 		if err2 != nil {
 			return fmt.Errorf("pushimage: %v", err2)
 		}


### PR DESCRIPTION
Docker was returning:

```
Bad parameters and missing X-Registry-Auth: EOF
```

This was coming from [here](https://github.com/docker/docker/blame/829ea91bd16c006facf2948cab89302ef2db7306/api/server/router/image/image_routes.go#L151).

It looks like you can't get away without supplying an X-Registry-Auth
header, even though a blank one works. I chose to supply an empty json
dictionary as authentication since it gets unserialized as json into an
[types.AuthConfig](https://github.com/docker/docker/blob/829ea91bd16c006facf2948cab89302ef2db7306/api/types/auth.go).

I don't know how this ever worked, or how I came to convince myself this
was working in the past, it looks like these code paths have been the
same for years.

I have tested this on QA and it appears to work. We'll need to cut a new
hanoverd release and do an infrastructure update.