### PR TITLE
Fix tests by correctly configuring netcat for newer alpine

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.8
 
 RUN apk --no-cache add netcat-openbsd
 

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -3,4 +3,4 @@ FROM alpine
 RUN apk --no-cache add netcat-openbsd
 
 EXPOSE 8000
-CMD ["sh", "-c", "while : ; do printf 'HTTP/1.0 200 OK\r\n\r\nHello from %s\r\n' $(hostname)| nc -l 8000; done"]
+CMD ["sh", "-c", "while : ; do printf 'HTTP/1.0 200 OK\r\n\r\nHello from %s\r\n' $(hostname) | nc -N -l 8000; done"]


### PR DESCRIPTION
The behaviour of netcat changed between alpine releases, breaking the
tests.

This PR fixes that behaviour by using the `-N` flag and pins alpine to
hopefully prevent future occurrences of such a mess.