### PR TITLE
Support docker buildkit

### DIFF
--- a/container.go
+++ b/container.go
@@ -374,10 +374,10 @@ func (c *Container) Run(imageSource source.ImageSource, payload []byte) (int64, 
 		c.Failed.Fall()
 		return -1, err
 	}
-	defer c.Delete()
 
 	err = c.Start()
 	if err != nil {
+		c.Delete() // Only attempt to delete if start fails, otherwise handled by AutoRemove.
 		c.Failed.Fall()
 		return -1, err
 	}

--- a/pkg/util/docker_client.go
+++ b/pkg/util/docker_client.go
@@ -7,7 +7,7 @@ import (
 // DockerClient configures a docker client.
 func DockerClient() (*client.Client, error) {
 	return client.NewClientWithOpts(
-		client.WithVersion("1.37"),
+		client.WithVersion("1.39"),
 		client.FromEnv,
 	)
 }

--- a/tests/multiple-ports/main.go
+++ b/tests/multiple-ports/main.go
@@ -77,8 +77,8 @@ func InitializeTLS(internalIPStr string) (*tls.Config, error) {
 		NotAfter:  time.Now().AddDate(2, 0, 0),     // 2 years
 
 		BasicConstraintsValid: true,
-		IsCA:           true, // We are an authority for ourselves.
-		MaxPathLenZero: true, // We're a self signed cert.
+		IsCA:                  true, // We are an authority for ourselves.
+		MaxPathLenZero:        true, // We're a self signed cert.
 
 		ExtKeyUsage: []x509.ExtKeyUsage{
 			x509.ExtKeyUsageClientAuth,


### PR DESCRIPTION
Rebase after #107.
==================

This pull request should make the `Version` field only get set if `DOCKER_BUILDKIT=1` is set, as the docker client does.

- [ ] Rebase after #107.
- [ ] Check environment variable.
- [ ] Toggle behaviour, including how parsing of response messages is done.