### PR TITLE
Fix test run failures for GitHub Actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,6 +14,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      # This permissions change wasn't previously needed, but
+      # without it the tests fail as iptables cannot access the lock file.
+      # It is preferable to running the tests as root.
+      # iptables within GitHub Actions' version of Ubuntu is
+      # version 1.8.4 as of 2021-03-18; more recent versions of iptables allow
+      # setting the lock file via the environment variable XTABLES_LOCKFILE.
+      - name: Set permissions on xtables.lock file
+        run: sudo chmod o+rw /run/xtables.lock
+
       - name: Run tests
         run:
           make test


### PR DESCRIPTION
Unsure why this is now happening. It was not previously required.
Possible that some operating system or iptables update has changed this
behaviour.

As the comment states, this is not an ideal fix, but is preferable to
`sudo make test`.