### PR TITLE
Remove `gomod` from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
It didn't update transitive dependencies, so you still have to manually
update anyway.

See #146 and then #149, which manually updated `containerd/containerd`
to `v1.6.6`.

Maybe this improves in future?